### PR TITLE
Bugfix: don't time out live connections

### DIFF
--- a/test/int/agent/test_stress.py
+++ b/test/int/agent/test_stress.py
@@ -52,7 +52,7 @@ async def test_reconnect_timeout_race(monkeypatch):
     """
     async with Assembly.start(counts={"default": 1}, reconnect_timeout=0) as asm:
         proc, _ = await asm.server.start(
-            "proc", spec.make_proc(["/usr/bin/sleep", "5"])
+            "proc", spec.make_proc(["/usr/bin/sleep", "3"])
         )
 
         # trigger a disconnection

--- a/test/int/agent/test_stress.py
+++ b/test/int/agent/test_stress.py
@@ -6,6 +6,7 @@ import pytest
 import sys
 
 from   procstar import spec
+from   procstar.agent.proc import ConnectionTimeoutError
 from   procstar.agent.server import maybe_set_reconnect_timeout
 from   procstar.testing.agent import Assembly
 
@@ -42,6 +43,25 @@ async def test_reconnect():
             timeout=30
         )
         assert all( r.status.exit_code == 0 for r in res )
+
+
+@pytest.mark.asyncio
+async def test_reconnect_timeout():
+    """
+    Test that reconnect timeout wont be set on live connections if agents concurrently
+    reconnect before the timeout would be set
+    """
+    async with Assembly.start(counts={"default": 1}, reconnect_timeout=0) as asm:
+        proc, _ = await asm.server.start(
+            "proc", spec.make_proc(["/usr/bin/sleep", "1"])
+        )
+
+        # trigger a disconnection
+        conn_id, = asm.conn_procs.keys()
+        await asm.server.connections[conn_id].ws.close()
+
+        with pytest.raises(ConnectionTimeoutError):
+            await asm.wait(proc)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Adds logic to not timeout connections where `conn.open is True`. Most of the code changes are to tests and to make this testable.