### PR TITLE
Bugfix: set a registration timeout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -930,7 +930,7 @@ dependencies = [
 
 [[package]]
 name = "procstar"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "assert_cmd",
  "base64",

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -22,7 +22,7 @@ use crate::shutdown;
 //------------------------------------------------------------------------------
 
 const PING_INTERVAL: Duration = Duration::from_secs(20);
-const PONG_TIMEOUT: Duration = Duration::from_secs(60);
+const READ_TIMEOUT: Duration = Duration::from_secs(60);
 
 /// The read end of a split websocket.
 pub type SocketReceiver = SplitStream<WebSocketStream<MaybeTlsStream<TcpStream>>>;
@@ -254,7 +254,7 @@ pub async fn run(
         let mut receiver = tokio_stream::StreamExt::timeout_repeating(
             receiver,
             // Avoid the instant first tick from a standard interval
-            time::interval_at(time::Instant::now() + PONG_TIMEOUT, PONG_TIMEOUT),
+            time::interval_at(time::Instant::now() + READ_TIMEOUT, READ_TIMEOUT),
         );
 
         // Simultaneously wait for an incoming websocket message or a
@@ -272,7 +272,7 @@ pub async fn run(
                 res = receiver.next() => {
                     let ws_msg = match res {
                         None => { warn!("msg stream end"); break },
-                        Some(Err(_)) => {warn!("timeout error after {:?}", PONG_TIMEOUT); break; }
+                        Some(Err(_)) => {warn!("timeout error after {:?}", READ_TIMEOUT); break; }
                         Some(Ok(ws_msg)) => ws_msg,
                     };
 

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -140,7 +140,8 @@ async fn connect(
             Some(Err(err)) => Err(err)?,
             None => Err(proto::Error::Close)?,
         }
-    }).await?
+    })
+    .await.unwrap_or(Err(Error::RegisterTimeout))
 }
 
 /// Constructs an outgoing message corresponding to a notification message.

--- a/src/err.rs
+++ b/src/err.rs
@@ -64,6 +64,7 @@ pub enum Error {
     Spec(spec::Error),
     /// Wraps a WebSocket connection error.
     Websocket(tokio_tungstenite::tungstenite::error::Error),
+    RegisterTimeout(tokio::time::error::Elapsed),
 }
 
 impl Error {
@@ -94,6 +95,7 @@ impl std::fmt::Display for Error {
             }
             Error::Spec(ref err) => err.fmt(f),
             Error::Websocket(ref err) => err.fmt(f),
+            Error::RegisterTimeout(_) => write!(f, "registration took too long"),
         }
     }
 }
@@ -149,6 +151,12 @@ impl From<spec::Error> for Error {
 impl From<tokio_tungstenite::tungstenite::Error> for Error {
     fn from(err: tokio_tungstenite::tungstenite::Error) -> Error {
         Error::Websocket(err)
+    }
+}
+
+impl From<tokio::time::error::Elapsed> for Error {
+    fn from(err: tokio::time::error::Elapsed) -> Error {
+        Error::RegisterTimeout(err)
     }
 }
 

--- a/src/err.rs
+++ b/src/err.rs
@@ -64,7 +64,7 @@ pub enum Error {
     Spec(spec::Error),
     /// Wraps a WebSocket connection error.
     Websocket(tokio_tungstenite::tungstenite::error::Error),
-    RegisterTimeout(tokio::time::error::Elapsed),
+    RegisterTimeout,
 }
 
 impl Error {
@@ -95,7 +95,7 @@ impl std::fmt::Display for Error {
             }
             Error::Spec(ref err) => err.fmt(f),
             Error::Websocket(ref err) => err.fmt(f),
-            Error::RegisterTimeout(_) => write!(f, "registration took too long"),
+            Error::RegisterTimeout => write!(f, "registration took too long"),
         }
     }
 }
@@ -151,12 +151,6 @@ impl From<spec::Error> for Error {
 impl From<tokio_tungstenite::tungstenite::Error> for Error {
     fn from(err: tokio_tungstenite::tungstenite::Error) -> Error {
         Error::Websocket(err)
-    }
-}
-
-impl From<tokio::time::error::Elapsed> for Error {
-    fn from(err: tokio::time::error::Elapsed) -> Error {
-        Error::RegisterTimeout(err)
     }
 }
 


### PR DESCRIPTION
Follow up to https://github.com/apsis-scheduler/procstar/pull/42 for handling network interruptions. 

This change is necessary because even if an agent detects it needs to reconnect from the ping/pongs, it still might hang indefinitely when reconnecting.

```
2025-02-12T22:05:03.181+00:00 - WARN - msg receive error: Io(Os { code: 104, kind: ConnectionReset, message: "Connection reset by peer" })
2025-02-12T22:05:03.182+00:00 - INFO - agent connecting: wss://apsis.asd:59789/
2025-02-12T23:24:01.685+00:00 - INFO - received: SIGTERM
```