### PR TITLE
Systemd integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1283,6 +1283,7 @@ dependencies = [
  "log",
  "matchit",
  "native-tls",
+ "nix",
  "rmp-serde",
  "serde",
  "serde_bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ libc = "0.2"
 log = "0.4"
 matchit = "0.7"
 native-tls = { version = "*", features = ["vendored"] }
+nix = { version = "0.30.1", features = ["event"] }
 rmp-serde = "1.2"
 serde = { version = "1.0", features = ["derive"] }
 serde_bytes = "0.11"

--- a/src/main.rs
+++ b/src/main.rs
@@ -164,7 +164,7 @@ async fn main() {
     // LocalSet since it starts other tasks itself.
     if !input.specs.is_empty() {
         let _tasks = local_set
-            .run_until(async { start_procs(input.specs, &procs) })
+            .run_until(start_procs(input.specs, &procs, systemd.clone()))
             .await
             .unwrap_or_else(|err| {
                 error!("failed to start processes: {}", err);

--- a/src/main.rs
+++ b/src/main.rs
@@ -135,6 +135,14 @@ async fn main() {
         restrict_exe(exe);
     }
 
+    let systemd = if let Some(client) = maybe_connect().await {
+        info!("systemd available");
+        Some(Rc::new(client))
+    } else {
+        warn!("user systemd with cgroups v2 unavailable");
+        None
+    };
+
     // We run tokio in single-threaded mode.
     let local_set = tokio::task::LocalSet::new();
 

--- a/src/procs.rs
+++ b/src/procs.rs
@@ -475,7 +475,7 @@ async fn finalize_slice(
 
     debug!("stopping slice: {}", slice);
     systemd
-        .stop(&slice)
+        .stop(slice)
         .await
         .unwrap_or_else(|err| error!("stop slice failed {slice}: {err}"));
 

--- a/src/procs.rs
+++ b/src/procs.rs
@@ -524,7 +524,7 @@ fn get_exe(exe: Option<String>, argv: &Vec<String>) -> String {
 ///
 /// Because this function starts tasks with `spawn_local`, it must be run within
 /// a `LocalSet`.
-pub fn start_procs(
+pub async fn start_procs(
     specs: spec::Procs,
     procs: &SharedProcs,
 ) -> Result<Vec<tokio::task::JoinHandle<()>>, Error> {

--- a/src/procs.rs
+++ b/src/procs.rs
@@ -57,7 +57,7 @@ pub struct Proc {
 impl Proc {
     pub fn new(
         pid: pid_t,
-        slice: Option<String>,
+        slice: Option<Slice>,
         start_time: DateTime<Utc>,
         start_instant: Instant,
         fd_handlers: FdHandlers,

--- a/src/res.rs
+++ b/src/res.rs
@@ -10,6 +10,7 @@ use crate::sig;
 use crate::spec::{CaptureEncoding, FdName, ProcId};
 use crate::state::State;
 use crate::string::elide;
+use crate::systemd::cgroup::CGroupAccounting;
 
 //------------------------------------------------------------------------------
 
@@ -222,6 +223,9 @@ pub struct ProcRes {
 
     /// Recent memory usage, if the process has not terminated.
     pub proc_statm: Option<ProcStatm>,
+
+    /// Accounting information read from the cgroup filesystem.
+    pub cgroup_accounting: Option<CGroupAccounting>,
 
     /// Process timing.
     pub times: Times,

--- a/src/spec.rs
+++ b/src/spec.rs
@@ -10,6 +10,7 @@ use std::string::String;
 use std::vec::Vec;
 
 use crate::sys::fd_t;
+use crate::systemd::manager::UnitProperty;
 
 //------------------------------------------------------------------------------
 // Spec error
@@ -326,6 +327,109 @@ pub fn validate_procs_fds(procs: &Procs) -> std::result::Result<(), Error> {
 }
 
 //------------------------------------------------------------------------------
+// Systemd spec
+//------------------------------------------------------------------------------
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum OOMPolicy {
+    Continue,
+    Stop,
+    Kill,
+}
+
+impl OOMPolicy {
+    fn as_str(&self) -> &'static str {
+        match self {
+            OOMPolicy::Continue => "continue",
+            OOMPolicy::Stop => "stop",
+            OOMPolicy::Kill => "kill",
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Scope {
+    pub oom_policy: Option<OOMPolicy>,
+    pub runtime_max_usec: Option<u64>,
+    pub runtime_randomized_extra_usec: Option<u64>,
+}
+
+impl<'a> From<Scope> for Vec<UnitProperty<'a>> {
+    fn from(scope: Scope) -> Self {
+        let mut output: Vec<UnitProperty> = Vec::new();
+
+        if let Some(val) = scope.oom_policy {
+            output.push(UnitProperty::from(("OOMPolicy", val.as_str())));
+        }
+        if let Some(val) = scope.runtime_max_usec {
+            output.push(UnitProperty::from(("RuntimeMaxUSec", val)));
+        }
+        if let Some(val) = scope.runtime_randomized_extra_usec {
+            output.push(UnitProperty::from(("RuntimeRandomizedExtraUSec", val)));
+        }
+
+        output
+    }
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Slice {
+    pub memory_accounting: Option<bool>,
+    pub memory_min: Option<u64>,
+    pub memory_low: Option<u64>,
+    pub memory_high: Option<u64>,
+    pub memory_max: Option<u64>,
+    pub memory_swap_max: Option<u64>,
+
+    pub tasks_accounting: Option<bool>,
+    pub tasks_max: Option<u64>,
+}
+
+impl<'a> From<Slice> for Vec<UnitProperty<'a>> {
+    fn from(slice: Slice) -> Self {
+        let mut output: Vec<UnitProperty> = Vec::new();
+
+        if let Some(val) = slice.memory_accounting {
+            output.push(UnitProperty::from(("MemoryAccounting", val)));
+        }
+        if let Some(val) = slice.memory_min {
+            output.push(UnitProperty::from(("MemoryMin", val)));
+        }
+        if let Some(val) = slice.memory_low {
+            output.push(UnitProperty::from(("MemoryLow", val)));
+        }
+        if let Some(val) = slice.memory_high {
+            output.push(UnitProperty::from(("MemoryHigh", val)));
+        }
+        if let Some(val) = slice.memory_max {
+            output.push(UnitProperty::from(("MemoryMax", val)));
+        }
+        if let Some(val) = slice.memory_swap_max {
+            output.push(UnitProperty::from(("MemorySwapMax", val)));
+        }
+
+        if let Some(val) = slice.tasks_accounting {
+            output.push(UnitProperty::from(("TasksAccounting", val)));
+        }
+        if let Some(val) = slice.tasks_max {
+            output.push(UnitProperty::from(("TasksMax", val)));
+        }
+
+        output
+    }
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields, default)]
+pub struct SystemdProperties {
+    pub scope: Scope,
+    pub slice: Slice,
+}
+
+//------------------------------------------------------------------------------
 // Process spec
 //------------------------------------------------------------------------------
 
@@ -338,6 +442,7 @@ pub struct Proc {
     pub argv: Vec<String>,
     pub env: Env,
     pub fds: Vec<(FdName, Fd)>,
+    pub systemd_properties: SystemdProperties,
 }
 
 pub type Procs = BTreeMap<ProcId, Proc>;

--- a/src/systemd/api.rs
+++ b/src/systemd/api.rs
@@ -1,0 +1,95 @@
+use super::cgroup::CGROUP_ROOT;
+use super::manager::{ManagerProxy, UnitProperty};
+use super::slice::SliceProxy;
+use futures_util::StreamExt;
+use log::debug;
+use std::path::PathBuf;
+use std::rc::Rc;
+use uuid::Uuid;
+
+// TODO: make this portable
+
+#[derive(Debug)]
+pub enum UnitType {
+    Slice,
+    Scope,
+}
+
+pub fn generate_unit_name(unit_type: UnitType) -> String {
+    let uuid = Uuid::new_v4();
+    let suffix = match unit_type {
+        UnitType::Slice => "slice",
+        UnitType::Scope => "scope",
+    };
+    format!("procstar{}.{}", uuid.as_simple(), suffix)
+}
+
+pub struct SystemdClient {
+    connection: zbus::Connection,
+    manager_proxy: ManagerProxy<'static>,
+}
+
+impl SystemdClient {
+    pub async fn new() -> Result<Self, zbus::Error> {
+        let connection = zbus::Connection::session().await?;
+        Ok(Self {
+            manager_proxy: ManagerProxy::new(&connection).await?,
+            connection,
+        })
+    }
+
+    pub async fn start_transient_unit(
+        &self,
+        unit_type: UnitType,
+        properties: &[UnitProperty<'_>],
+    ) -> Result<String, zbus::Error> {
+        let name = generate_unit_name(unit_type);
+
+        let mut removed_stream = self.manager_proxy.receive_job_removed().await?;
+
+        // request to start unit
+        let job_path = self
+            .manager_proxy
+            .start_transient_unit(&name, "replace", properties, &[])
+            .await?;
+
+        // wait for request to actually complete
+        while let Some(job_removed) = removed_stream.next().await {
+            let args = job_removed.args()?;
+            if *job_path == *args.job() {
+                break;
+            }
+        }
+        Ok(name)
+    }
+
+    // FIXME: generalize to any unit type?
+    pub async fn get_slice_cgroup_path(&self, name: &str) -> Result<PathBuf, zbus::Error> {
+        let unit_path = self.manager_proxy.get_unit(name).await?;
+        let slice_proxy = SliceProxy::new(&self.connection, &unit_path).await?;
+        let cgroup_rel = slice_proxy.control_group().await?;
+        Ok(CGROUP_ROOT.join(cgroup_rel.trim_start_matches("/")))
+    }
+
+    pub async fn stop(&self, name: &str) -> Result<(), zbus::Error> {
+        self.manager_proxy.stop_unit(name, "replace").await?;
+        Ok(())
+    }
+}
+
+pub type SharedSystemdClient = Rc<SystemdClient>;
+
+pub async fn maybe_connect() -> Option<SystemdClient> {
+    let systemd = SystemdClient::new()
+        .await
+        .map_err(|err| {
+            debug!("unable to create systemd client: {err}");
+        })
+        .ok()?;
+
+    if !CGROUP_ROOT.join("cgroup.controllers").is_file() {
+        debug!("cgroup v2 hierarchy not detected");
+        return None;
+    }
+    Some(systemd)
+}

--- a/src/systemd/api.rs
+++ b/src/systemd/api.rs
@@ -80,16 +80,14 @@ impl SystemdClient {
 pub type SharedSystemdClient = Rc<SystemdClient>;
 
 pub async fn maybe_connect() -> Option<SystemdClient> {
-    let systemd = SystemdClient::new()
-        .await
-        .map_err(|err| {
-            debug!("unable to create systemd client: {err}");
-        })
-        .ok()?;
-
     if !CGROUP_ROOT.join("cgroup.controllers").is_file() {
         debug!("cgroup v2 hierarchy not detected");
         return None;
     }
-    Some(systemd)
+    SystemdClient::new()
+        .await
+        .map_err(|err| {
+            debug!("unable to create systemd client: {err}");
+        })
+        .ok()
 }

--- a/src/systemd/cgroup.rs
+++ b/src/systemd/cgroup.rs
@@ -1,0 +1,190 @@
+// TODO: load other interesting accounting files
+
+use log::error;
+use serde::{Deserialize, Serialize};
+use std::{
+    collections::{HashMap, HashSet},
+    fmt, fs, io,
+    path::PathBuf,
+    str::FromStr,
+    sync::LazyLock,
+};
+
+// TODO: make this portable
+pub static CGROUP_ROOT: LazyLock<PathBuf> = LazyLock::new(|| PathBuf::from("/sys/fs/cgroup"));
+
+pub enum Error {
+    Io(std::io::Error),
+    Parse(PathBuf),
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Error::Io(err) => err.fmt(f),
+            Error::Parse(target) => write!(f, "failed to parse: {target:?}"),
+        }
+    }
+}
+
+impl From<io::Error> for Error {
+    fn from(err: io::Error) -> Error {
+        Error::Io(err)
+    }
+}
+
+fn load_scalar<T: FromStr>(path: &PathBuf) -> Result<T, Error> {
+    std::fs::read_to_string(path)?
+        .trim()
+        .parse()
+        .map_err(|_| Error::Parse(path.file_name().map_or(PathBuf::from(""), PathBuf::from)))
+}
+
+fn load_flat_keyed<T: FromStr>(path: &PathBuf) -> Result<HashMap<String, T>, Error> {
+    let contents = std::fs::read_to_string(path)?.trim().to_owned();
+    let mut output = HashMap::new();
+
+    let name = path.file_name().map_or(PathBuf::from(""), PathBuf::from);
+
+    for line in contents.lines() {
+        let mut parts = line.split_whitespace();
+        if let (Some(k), Ok(v)) = (
+            parts.next(),
+            parts.next().ok_or(Error::Parse(name.clone()))?.parse::<T>(),
+        ) {
+            output.insert(k.to_owned(), v);
+        } else {
+            return Err(Error::Parse(name.clone()));
+        }
+    }
+
+    return Ok(output);
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+struct Pids {
+    pub current: u64,
+    pub peak: u64,
+}
+
+impl Pids {
+    pub fn load(cgroup_path: &PathBuf) -> Result<Self, Error> {
+        let load_scalar = |filename| load_scalar(&cgroup_path.join(filename));
+        Ok(Self {
+            current: load_scalar("pids.current")?,
+            peak: load_scalar("pids.peak")?,
+        })
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+struct CPUStat {
+    pub usage_usec: u64,
+    pub user_usec: u64,
+    pub system_usec: u64,
+    // below are only available when cpu controller is enabled
+    pub nr_periods: Option<u64>,
+    pub nr_throttled: Option<u64>,
+    pub throttled_usec: Option<u64>,
+    pub nr_bursts: Option<u64>,
+    pub burst_usec: Option<u64>,
+}
+
+impl CPUStat {
+    pub fn load(cgroup_path: &PathBuf) -> Result<Self, Error> {
+        let stat_rel = PathBuf::from("cpu.stat");
+        let mut mapping: HashMap<String, u64> = load_flat_keyed(&cgroup_path.join(&stat_rel))?;
+        Ok(Self {
+            usage_usec: mapping
+                .remove("usage_usec")
+                .ok_or(Error::Parse(stat_rel.clone()))?,
+            user_usec: mapping
+                .remove("user_usec")
+                .ok_or(Error::Parse(stat_rel.clone()))?,
+            system_usec: mapping
+                .remove("system_usec")
+                .ok_or(Error::Parse(stat_rel.clone()))?,
+            // optional, only available if cpu controller is enabled
+            nr_periods: mapping.remove("nr_periods"),
+            nr_throttled: mapping.remove("nr_throttled"),
+            throttled_usec: mapping.remove("throttled_usec"),
+            nr_bursts: mapping.remove("nr_bursts"),
+            burst_usec: mapping.remove("burst_usec"),
+        })
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+struct Memory {
+    pub current: u64,
+    pub peak: u64,
+    pub swap_current: u64,
+    pub swap_peak: u64,
+}
+
+impl Memory {
+    pub fn load(cgroup_path: &PathBuf) -> Result<Self, Error> {
+        let load_scalar = |filename| load_scalar(&cgroup_path.join(filename));
+
+        Ok(Memory {
+            current: load_scalar("memory.current")?,
+            peak: load_scalar("memory.peak")?,
+            swap_current: load_scalar("memory.swap.current")?,
+            swap_peak: load_scalar("memory.swap.peak")?,
+        })
+    }
+}
+
+fn enabled_controllers(cgroup_path: &PathBuf) -> Result<HashSet<String>, Error> {
+    let control_file = if *cgroup_path == *CGROUP_ROOT {
+        // in the root cgroup, cgroup.controllers reports all the controllers that can
+        // be enabled, not necessarily the ones that are
+        cgroup_path.join("cgroup.subtree_control")
+    } else {
+        // in non-root cgroups this corresponds the parent's cgroup.subtree_control and
+        // does track which accounting and control files will be available
+        cgroup_path.join("cgroup.controllers")
+    };
+
+    Ok(fs::read_to_string(control_file)?
+        .split_whitespace()
+        .map(|s| s.to_owned())
+        .collect())
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+pub struct CGroupAccounting {
+    pids: Option<Pids>,
+    cpu_stat: Option<CPUStat>,
+    memory: Option<Memory>,
+}
+
+impl CGroupAccounting {
+    pub fn load(cgroup_path: &PathBuf) -> Result<Self, Error> {
+        let controllers = enabled_controllers(cgroup_path)?;
+        Ok(CGroupAccounting {
+            pids: if controllers.contains("pids") {
+                Some(Pids::load(cgroup_path)?)
+            } else {
+                None
+            },
+            memory: if controllers.contains("memory") {
+                Some(Memory::load(cgroup_path)?)
+            } else {
+                None
+            },
+            // always load CPU because some cput.stat fields are available even when
+            // the controller isn't enabled
+            cpu_stat: Some(CPUStat::load(cgroup_path)?),
+        })
+    }
+
+    pub fn load_or_log(cgroup_path: &PathBuf) -> Option<Self> {
+        Self::load(cgroup_path)
+            .or_else(|err| {
+                error!("failed to load accounting for {}", cgroup_path.display());
+                Err(err)
+            })
+            .ok()
+    }
+}

--- a/src/systemd/mod.rs
+++ b/src/systemd/mod.rs
@@ -1,3 +1,5 @@
+pub mod api;
+pub mod cgroup;
 pub mod manager;
 pub mod slice;
 pub mod unit;


### PR DESCRIPTION
Addressed the comments in the [draft PR](https://github.com/apsis-scheduler/procstar/pull/48) and cleaned up the commits. 

The main thing I didn't get to is cleaning up slices if there's a crash. I'm holding off for now because I'm not sure it's necessary enough compared to how difficult/inelegant it is. 
- Multiple procstar instances can be running as the same user, so it's not obvious how to determine slice ownership to clean up at startup. It feels weird to race to clean up resources that might not be yours.
- Slices consume next to no resources and only exist until the next reboot.

I'm going to do the spec changes on the Python side in a follow up PR.

