### PR TITLE
Ensure procstar server is compatible with agents on old version

### DIFF
--- a/python/procstar/spec.py
+++ b/python/procstar/spec.py
@@ -262,7 +262,7 @@ class Proc:
 
 
     def __init__(
-        self, argv, *, env=Env(), fds={}, systemd_properties=SystemdProperties()
+        self, argv, *, env=Env(), fds={}, systemd_properties=None,
     ):
         self.__argv = tuple( str(a) for a in argv )
         self.__env  = env
@@ -272,11 +272,16 @@ class Proc:
 
     def to_jso(self):
         return {
-            "argv"  : self.__argv,
-            "env"   : self.__env.to_jso(),
-            "fds"   : [ (n, f.to_jso()) for n, f in self.__fds.items() ],
-            "systemd_properties": self.__systemd_properties.to_jso(),
-        }
+            "argv": self.__argv,
+            "env": self.__env.to_jso(),
+            "fds": [(n, f.to_jso()) for n, f in self.__fds.items()],
+        } | (
+            {}
+            if self.__systemd_properties is None
+            # only insert systemd_properties field if its explicitly set to remain
+            # compatible with agents that don't yet support it
+            else {"systemd_properties": self.__systemd_properties.to_jso()}
+        )
 
 
 

--- a/test/int/test_systemd.py
+++ b/test/int/test_systemd.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 import pytest
 
+from procstar.spec import Proc
 from procstar.testing.proc import run1
 from procstar.testing import systemd
 
@@ -51,3 +52,15 @@ def test_unavailable():
         }
     )
     assert res["cgroup_accounting"] is None
+
+
+def test_backward_compatibility():
+    """
+    Double check that a spec that doesn't mention systemd is still compatible with
+    old agents that don't yet have systemd features.
+    """
+    assert not "systemd_properties" in Proc(["/usr/bin/true"]).to_jso()
+    assert (
+        "systemd_properties"
+        in Proc(["/usr/bin/true"], systemd_properties=Proc.SystemdProperties()).to_jso()
+    )


### PR DESCRIPTION
Follow up to https://github.com/apsis-scheduler/procstar/pull/50, allowing procstar server that supports systemd to be compatible with old agents that don't yet.