### PR TITLE
Bugfix: RefCell borrow panic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1264,7 +1264,7 @@ dependencies = [
 
 [[package]]
 name = "procstar"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "assert_cmd",
  "base64",

--- a/src/procs.rs
+++ b/src/procs.rs
@@ -505,9 +505,12 @@ async fn wait_for_proc(
             let stop_time = Utc::now();
             let stop_instant = Instant::now();
 
-            let mut proc = proc.borrow_mut();
+            let slice = proc.borrow().slice.clone();
+            // important: don't await while proc is borrowed mutably to avoid runtime
+            // borrow check failures
+            let cgroup_accounting = finalize_slice(slice.as_ref(), systemd).await;
 
-            let cgroup_accounting = finalize_slice(proc.slice.as_ref(), systemd).await;
+            let mut proc = proc.borrow_mut();
 
             // Process terminated; update its stuff.
             assert!(proc.wait_info.is_none());


### PR DESCRIPTION
Fixes a runtime borrow failure introduced in https://github.com/apsis-scheduler/procstar/pull/50. It's because I introduced an [await after `proc.borrow_mut()` ](https://github.com/apsis-scheduler/procstar/blob/fa8df93775decdad26c3f10e4e4f13a16e7ae781/src/procs.rs#L510).

```
stack backtrace:
   0: rust_begin_unwind
   1: core::panicking::panic_fmt
   2: core::cell::panic_already_mutably_borrowed
   3: procstar::proto::handle_incoming::{{closure}}
   4: <core::pin::Pin<P> as core::future::future::Future>::poll
   5: <core::future::poll_fn::PollFn<F> as core::future::future::Future>::poll
   6: <tokio::future::maybe_done::MaybeDone<Fut> as core::future::future::Future>::poll
   7: <core::future::poll_fn::PollFn<F> as core::future::future::Future>::poll
   8: <tokio::task::local::RunUntil<T> as core::future::future::Future>::poll
   9: procstar::main::{{closure}}
  10: tokio::runtime::scheduler::current_thread::Context::enter
  11: tokio::runtime::context::set_scheduler
  12: tokio::runtime::scheduler::current_thread::CoreGuard::block_on
  13: tokio::runtime::context::runtime::enter_runtime
  14: tokio::runtime::scheduler::current_thread::CurrentThread::block_on
  15: procstar::main
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
```

I managed to reproduce the error and ensure the fix worked, but I'm not committing the test because it requires putting a sleep in `finalize_slice`.

Clippy would've caught this, so it's a priority to fix clippy errors and enforce them in CI.