### PR TITLE
Migrate to new websockets asyncio implementation

### DIFF
--- a/python/procstar/agent/conn.py
+++ b/python/procstar/agent/conn.py
@@ -10,8 +10,7 @@ import ipaddress
 import logging
 import random
 import time
-import websockets.protocol
-from   websockets.asyncio.server import ServerConnection
+from   websockets import ServerConnection, State
 from   websockets.exceptions import ConnectionClosedError
 
 from   .exc import NoOpenConnectionInGroup, NotConnectedError, WebSocketNotOpen

--- a/python/procstar/agent/conn.py
+++ b/python/procstar/agent/conn.py
@@ -157,7 +157,7 @@ class Connection:
 
     @property
     def open(self):
-        return self.ws.state is websockets.protocol.State.OPEN
+        return self.ws.state == websockets.protocol.State.OPEN
 
 
     async def send(self, msg):

--- a/python/procstar/agent/conn.py
+++ b/python/procstar/agent/conn.py
@@ -157,20 +157,20 @@ class Connection:
 
     @property
     def open(self):
-        return self.ws.state == websockets.protocol.State.OPEN
+        return self.ws.state == State.OPEN
 
 
     async def send(self, msg):
         if self.ws is None:
             raise NotConnectedError(self.conn_id)
-        if not self.ws.state is websockets.protocol.State.OPEN:
+        if not self.ws.state == State.OPEN:
             raise WebSocketNotOpen(self.conn_id)
 
         data = serialize_message(msg)
         try:
             await self.ws.send(data)
         except ConnectionClosedError:
-            assert self.ws.state is websockets.protocol.State.CLOSED
+            assert self.ws.state == State.CLOSED
             # Connection closed.  Don't forget about it; it may reconnect.
             logger.warning(f"{self.info.socket}: connection closed")
             # FIXME: Think carefully the temporarily dropped connection logic.
@@ -282,7 +282,7 @@ class Connections(Mapping, Subscribeable):
                 raise RuntimeError(f"[{conn_id}] new group: {group}")
 
             # If the old connection websocket still open, close it.
-            if not old_conn.ws.state is websockets.protocol.State.CLOSED:
+            if not old_conn.ws.state == State.CLOSED:
                 logger.warning(f"[{conn_id}] closing old connection")
                 _ = asyncio.create_task(old_conn.ws.close())
 

--- a/python/procstar/agent/conn.py
+++ b/python/procstar/agent/conn.py
@@ -10,6 +10,8 @@ import ipaddress
 import logging
 import random
 import time
+import websockets.protocol
+from   websockets.asyncio.server import ServerConnection
 from   websockets.exceptions import ConnectionClosedError
 
 from   .exc import NoOpenConnectionInGroup, NotConnectedError, WebSocketNotOpen
@@ -133,7 +135,7 @@ class Connection:
     """
 
     info: ProcstarInfo
-    ws: asyncio.protocols.Protocol = None
+    ws: ServerConnection = None
     shutdown_state: ShutdownState = ShutdownState.active
 
     __reconnect_timeout_task: asyncio.Future = None
@@ -156,20 +158,20 @@ class Connection:
 
     @property
     def open(self):
-        return self.ws.open
+        return self.ws.state is websockets.protocol.State.OPEN
 
 
     async def send(self, msg):
         if self.ws is None:
             raise NotConnectedError(self.conn_id)
-        if not self.ws.open:
+        if not self.ws.state is websockets.protocol.State.OPEN:
             raise WebSocketNotOpen(self.conn_id)
 
         data = serialize_message(msg)
         try:
             await self.ws.send(data)
         except ConnectionClosedError:
-            assert self.ws.closed
+            assert self.ws.state is websockets.protocol.State.CLOSED
             # Connection closed.  Don't forget about it; it may reconnect.
             logger.warning(f"{self.info.socket}: connection closed")
             # FIXME: Think carefully the temporarily dropped connection logic.
@@ -281,7 +283,7 @@ class Connections(Mapping, Subscribeable):
                 raise RuntimeError(f"[{conn_id}] new group: {group}")
 
             # If the old connection websocket still open, close it.
-            if not old_conn.ws.closed:
+            if not old_conn.ws.state is websockets.protocol.State.CLOSED:
                 logger.warning(f"[{conn_id}] closing old connection")
                 _ = asyncio.create_task(old_conn.ws.close())
 

--- a/python/procstar/agent/server.py
+++ b/python/procstar/agent/server.py
@@ -169,7 +169,7 @@ class Server:
 
         Use this bound method with `websockets.serve()`.
         """
-        assert ws.state is websockets.protocol.State.OPEN
+        assert ws.state == websockets.protocol.State.OPEN
         time = now()
 
         try:

--- a/python/procstar/agent/server.py
+++ b/python/procstar/agent/server.py
@@ -8,7 +8,8 @@ import logging
 import os
 from   pathlib import Path
 import ssl
-import websockets.server
+import websockets
+import websockets.protocol
 from   websockets.exceptions import ConnectionClosedOK, ConnectionClosedError
 
 from   . import DEFAULT_PORT
@@ -149,7 +150,7 @@ class Server:
                 logger.debug(f"TLS: {args}")
             ssl_context._msg_callback = msg_callback
 
-        return websockets.server.serve(
+        return websockets.serve(
             partial(self._serve_connection, access_token, reconnect_timeout),
             host, port,
             ssl=ssl_context,
@@ -168,7 +169,7 @@ class Server:
 
         Use this bound method with `websockets.server.serve()`.
         """
-        assert ws.open
+        assert ws.state is websockets.protocol.State.OPEN
         time = now()
 
         try:

--- a/python/procstar/agent/server.py
+++ b/python/procstar/agent/server.py
@@ -167,7 +167,7 @@ class Server:
         """
         Serves an incoming connection.
 
-        Use this bound method with `websockets.server.serve()`.
+        Use this bound method with `websockets.serve()`.
         """
         assert ws.state is websockets.protocol.State.OPEN
         time = now()

--- a/test/int/agent/test_reconnect.py
+++ b/test/int/agent/test_reconnect.py
@@ -30,7 +30,7 @@ async def test_ws_reconnect():
                 # Close the connection.
                 conn, = asm.server.connections.values()
                 await conn.ws.close()
-                assert conn.ws.closed
+                assert not conn.open
                 # Wait for reconnect.
                 conn_id, conn = await anext(sub)
 
@@ -60,7 +60,7 @@ async def test_ws_reconnect_nowait():
         # Close the connection.
         conn, = asm.server.connections.values()
         await conn.ws.close()
-        assert conn.ws.closed
+        assert not conn.open
 
         # Wait for results anyway.  The procstar instance should reconnect.
         res0, res1 = await asyncio.gather(asm.wait(proc0), asm.wait(proc1))

--- a/test/int/agent/test_reconnect_timeout.py
+++ b/test/int/agent/test_reconnect_timeout.py
@@ -30,6 +30,16 @@ async def test_reconnect_timeout_race(monkeypatch):
     Test that reconnect timeout wont be set on live connections if agents concurrently
     reconnect before the timeout would be set
     """
+
+    async def mock_set_reconnect(*args, **kwargs):
+        # give agent a chance to reconnect before setting the reconnect timeout
+        await asyncio.sleep(1)
+        return await maybe_set_reconnect_timeout(*args, **kwargs)
+
+    monkeypatch.setattr(
+        "procstar.agent.server.maybe_set_reconnect_timeout", mock_set_reconnect
+    )
+
     async with Assembly.start(counts={"default": 1}, reconnect_timeout=0) as asm:
         proc, _ = await asm.server.start(
             "proc", spec.make_proc([shutil.which("sleep"), "3"])
@@ -39,13 +49,5 @@ async def test_reconnect_timeout_race(monkeypatch):
         (conn_id,) = asm.conn_procs.keys()
         await asm.server.connections[conn_id].ws.close()
 
-        async def mock_set_reconnect(*args, **kwargs):
-            # give agent a chance to reconnect before setting the reconnect timeout
-            await asyncio.sleep(1)
-            return await maybe_set_reconnect_timeout(*args, **kwargs)
-
-        monkeypatch.setattr(
-            "procstar.agent.server.maybe_set_reconnect_timeout", mock_set_reconnect
-        )
         res = await asm.wait(proc)
         assert res.status.exit_code == 0


### PR DESCRIPTION
https://websockets.readthedocs.io/en/stable/howto/upgrade.html

In my tests I found that this implementation is less susceptible to dropping messages on agent reconnect. 

The problem with the old one is that it uses a background task to asynchronously update the websocket state (open vs closed), so in some cases the server can send messages to a websocket it thinks is open but really isn't, dropping them.