### PR TITLE
Older manylinux

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,6 +59,10 @@ jobs:
       with:
         command: build
         sccache: true
+        manylinux: auto
+        container: quay.io/pypa/manylinux_2_28_x86_64:latest
+        before-script-linux: |
+          dnf install -y perl-IPC-Cmd
         args: --release
 
     - name: Create pypi-index directory


### PR DESCRIPTION
We need to build wheels with an older version of libc. manylinux 2_39 won't run in many places https://apsis-scheduler.github.io/procstar/simple/procstar/index.html.